### PR TITLE
p cutoff line

### DIFF
--- a/R/easyVolcano.R
+++ b/R/easyVolcano.R
@@ -16,6 +16,8 @@
 #' @param fdrcutoff Cut-off for FDR significance. Defaults to FDR < 0.05. If `y` 
 #' is specified manually and `padj` is left blank then this refers to the 
 #' cut-off for significant points using nominal unadjusted p values. 
+#' @param pcutoff Cut-off for nominal unadjusted P value significance if FDR is 
+#' not used. Defaults to P < 0.05.
 #' @param fccut Optional vector of log fold change cut-offs.
 #' @param colScheme Colour scheme. If no fold change cut-off is set, 2 colours
 #' need to be specified. With a single fold change cut-off, 3 or 5 colours are
@@ -39,7 +41,7 @@
 
 
 easyVolcano <- function(data, x = NULL, y = NULL, padj = y,
-                        fdrcutoff = 0.05, fccut = NULL,
+                        fdrcutoff = 0.05, pcutoff = 0.05, fccut = NULL,
                         colScheme = c('darkgrey', 'blue', 'red'),
                         xlab = expression("log"[2] ~ " fold change"),
                         ylab = expression("-log"[10] ~ " P"),
@@ -79,9 +81,13 @@ easyVolcano <- function(data, x = NULL, y = NULL, padj = y,
     siggenes <- data[, padj] < fdrcutoff
   }
   siggenes[is.na(siggenes)] <- FALSE
-  if (sum(siggenes) >0) {
+  if (sum(siggenes) >0 & y != padj) {
     fdrline <- min(data[siggenes, 'log10P'])
-  } else fdrline <- NULL
+  } else if (sum(siggenes) >0 & y == padj){
+    fdrline <- -log(pcutoff, 10)
+  } else {
+    fdrline <- NULL
+  }
   if (showCounts) {
     up <- sum(siggenes & data[, x] > 0)
     down <- sum(siggenes & data[, x] < 0)

--- a/R/easyVolcano.R
+++ b/R/easyVolcano.R
@@ -16,8 +16,6 @@
 #' @param fdrcutoff Cut-off for FDR significance. Defaults to FDR < 0.05. If `y` 
 #' is specified manually and `padj` is left blank then this refers to the 
 #' cut-off for significant points using nominal unadjusted p values. 
-#' @param pcutoff Cut-off for nominal unadjusted P value significance if FDR is 
-#' not used. Defaults to P < 0.05.
 #' @param fccut Optional vector of log fold change cut-offs.
 #' @param colScheme Colour scheme. If no fold change cut-off is set, 2 colours
 #' need to be specified. With a single fold change cut-off, 3 or 5 colours are
@@ -41,7 +39,7 @@
 
 
 easyVolcano <- function(data, x = NULL, y = NULL, padj = y,
-                        fdrcutoff = 0.05, pcutoff = 0.05, fccut = NULL,
+                        fdrcutoff = 0.05, fccut = NULL,
                         colScheme = c('darkgrey', 'blue', 'red'),
                         xlab = expression("log"[2] ~ " fold change"),
                         ylab = expression("-log"[10] ~ " P"),
@@ -81,10 +79,8 @@ easyVolcano <- function(data, x = NULL, y = NULL, padj = y,
     siggenes <- data[, padj] < fdrcutoff
   }
   siggenes[is.na(siggenes)] <- FALSE
-  if (sum(siggenes) >0 & y != padj) {
-    fdrline <- min(data[siggenes, 'log10P'])
-  } else if (sum(siggenes) >0 & y == padj){
-    fdrline <- -log(pcutoff, 10)
+  if (sum(siggenes) >0) {
+    fdrline <- -log(fdrcutoff, 10)
   } else {
     fdrline <- NULL
   }

--- a/man/easyVolcano.Rd
+++ b/man/easyVolcano.Rd
@@ -10,7 +10,6 @@ easyVolcano(
   y = NULL,
   padj = y,
   fdrcutoff = 0.05,
-  pcutoff = 0.05,
   fccut = NULL,
   colScheme = c("darkgrey", "blue", "red"),
   xlab = expression("log"[2] ~ " fold change"),
@@ -38,9 +37,6 @@ p values are used for cut-off for significance instead of adjusted p values.}
 \item{fdrcutoff}{Cut-off for FDR significance. Defaults to FDR < 0.05. If \code{y}
 is specified manually and \code{padj} is left blank then this refers to the
 cut-off for significant points using nominal unadjusted p values.}
-
-\item{pcutoff}{Cut-off for nominal unadjusted P value significance if FDR is
-not used. Defaults to P < 0.05.}
 
 \item{fccut}{Optional vector of log fold change cut-offs.}
 

--- a/man/easyVolcano.Rd
+++ b/man/easyVolcano.Rd
@@ -10,6 +10,7 @@ easyVolcano(
   y = NULL,
   padj = y,
   fdrcutoff = 0.05,
+  pcutoff = 0.05,
   fccut = NULL,
   colScheme = c("darkgrey", "blue", "red"),
   xlab = expression("log"[2] ~ " fold change"),
@@ -37,6 +38,9 @@ p values are used for cut-off for significance instead of adjusted p values.}
 \item{fdrcutoff}{Cut-off for FDR significance. Defaults to FDR < 0.05. If \code{y}
 is specified manually and \code{padj} is left blank then this refers to the
 cut-off for significant points using nominal unadjusted p values.}
+
+\item{pcutoff}{Cut-off for nominal unadjusted P value significance if FDR is
+not used. Defaults to P < 0.05.}
 
 \item{fccut}{Optional vector of log fold change cut-offs.}
 


### PR DESCRIPTION
Don't know if this is an appropriate edit for easyVolcano in the easylabel package but had to do make an edit to easyVolcano so that the significance line is actually at the appropriate value (-log(0.05, 10) for my purpose), especially when using unadjust P values. Otherwise, it will take the smallest p value of those that are significant, which may not be close to the intended cutoff.